### PR TITLE
Fix broken Minitest output

### DIFF
--- a/lib/anyt/ext/minitest.rb
+++ b/lib/anyt/ext/minitest.rb
@@ -2,6 +2,7 @@
 
 ENV["TERM"] = "#{ENV["TERM"]}color" unless ENV["TERM"]&.match?(/color/)
 require "minitest/spec"
+require "minitest/unit"
 require "minitest/reporters"
 
 module Anyt

--- a/lib/anyt/version.rb
+++ b/lib/anyt/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Anyt
-  VERSION = "1.2.3"
+  VERSION = "1.2.4"
 end


### PR DESCRIPTION
Fix broken Minitest output by requiring an "ancient" Minitest::Unit

It's broken by the upstream change:
https://github.com/minitest/minitest/blob/v5.20.0/History.rdoc?plain=1#L12

---
Version bump as the change is critical and trivial